### PR TITLE
add wrappers for crypto_onetimeauth

### DIFF
--- a/src/crypto_onetimeauth.rs
+++ b/src/crypto_onetimeauth.rs
@@ -1,0 +1,122 @@
+use ffi;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum CryptoOnetimeAuthErr {
+    OnetimeAuth,
+    Verify,
+}
+
+/// Authenticate a message.
+///
+/// The `crypto_onetimeauth()` function authenticates a message `m` using a
+/// secret key `k`, and returns an authenticator `a`. The authenticator length
+/// is always `crypto_onetimeauth_BYTES`.
+///
+/// # Failures
+///
+/// `CryptoOnetimeAuthErr` is returned if an internal error occurs.
+///
+/// # Examples
+///
+/// Authenticating a message:
+///
+/// ```
+/// let authenticator = crypto_onetimeauth(&m, &k)
+///                         .ok()
+///                         .expect("onetimeauth failed!");
+/// ```
+///
+pub fn crypto_onetimeauth(m: &[u8], k: &[u8; ffi::crypto_onetimeauth_KEYBYTES])
+-> Result<[u8; ffi::crypto_onetimeauth_BYTES], CryptoOnetimeAuthErr> {
+
+    let mut out = [0 as u8; ffi::crypto_onetimeauth_BYTES];
+
+    unsafe {
+        match ffi::crypto_onetimeauth_poly1305_tweet(
+                        out.as_mut_ptr(),
+                        m.as_ptr(),
+                        m.len() as u64,
+                        k.as_ptr()) {
+            0 => Ok(out),
+            _ => Err(CryptoOnetimeAuthErr::OnetimeAuth),
+        }
+    }
+}
+
+/// Verify a message.
+///
+/// This function checks that `a` is a correct authenticator of a message `m`
+/// under the secret key `k`.
+///
+/// # Failures
+///
+/// `CryptoOnetimeAuthErr::Verify` is returned if `m` fails verification.
+///
+/// # Examples
+///
+pub fn crypto_onetimeauth_verify(a: &[u8; ffi::crypto_onetimeauth_BYTES],
+                                 m: &[u8],
+                                 k: &[u8; ffi::crypto_onetimeauth_KEYBYTES])
+-> Result<(), CryptoOnetimeAuthErr> {
+
+    unsafe {
+        match ffi::crypto_onetimeauth_poly1305_tweet_verify(
+                        a.as_ptr(),
+                        m.as_ptr(),
+                        m.len() as u64,
+                        k.as_ptr()) {
+            0 => Ok(()),
+            _ => Err(CryptoOnetimeAuthErr::Verify),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ffi;
+    use super::*;
+
+    static M: [u8; 3] = [1, 2, 3];
+    static K: [u8; ffi::crypto_onetimeauth_KEYBYTES] =
+        [94, 160, 2, 50, 215, 69, 14, 177, 153, 175, 171, 118, 23, 86, 2, 147,
+         51, 121, 188, 153, 175, 42, 81, 94, 184, 117, 143, 111, 237, 69, 51,
+         215];
+    static A: [u8; ffi::crypto_onetimeauth_BYTES] =
+        [201, 163, 29, 224, 47, 33, 105, 33, 195, 102, 99, 116, 193, 131, 36,
+         245];
+
+    #[test]
+    pub fn crypto_onetimeauth_ok() {
+        let result = crypto_onetimeauth(&M, &K).ok().expect("failed!");
+        assert_eq!(result, A);
+    }
+
+    #[test]
+    pub fn crypto_onetimeauth_verify_ok() {
+        let result = crypto_onetimeauth_verify(&A, &M, &K)
+                            .ok()
+                            .expect("failed!");
+        assert_eq!(result, ());
+    }
+
+    #[test]
+    pub fn crypto_onetimeauth_verify_fail() {
+        let mut bad_a = A.clone();
+        bad_a[0] = bad_a[0] ^ 1;
+
+        let mut bad_m = M.clone();
+        bad_m[0] = bad_m[0] ^ 1;
+
+        let mut bad_k = K.clone();
+        bad_k[0] = bad_k[0] ^ 1;
+
+        let result = crypto_onetimeauth_verify(&bad_a, &M, &K);
+        assert_eq!(result, Err(CryptoOnetimeAuthErr::Verify));
+
+        let result = crypto_onetimeauth_verify(&A, &bad_m, &K);
+        assert_eq!(result, Err(CryptoOnetimeAuthErr::Verify));
+
+        let result = crypto_onetimeauth_verify(&A, &M, &bad_k);
+        assert_eq!(result, Err(CryptoOnetimeAuthErr::Verify));
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]  // TODO: Remove this later.
 
-use libc::{size_t, c_int};
+use libc::{c_int};
 
 pub const crypto_auth_BYTES: usize = 32;
 pub const crypto_auth_KEYBYTES: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate rand;
 
 mod ffi;
 
+pub mod crypto_onetimeauth;
 pub mod randombytes;
 
 pub fn crypto_verify_16(x: &[u8], y: &[u8]) {
@@ -26,18 +27,6 @@ pub fn crypto_stream(out: &mut[u8], d: u64, n: &[u8], k: &[u8]) {
 pub fn crypto_stream_xor(c: &mut[u8], m: &[u8], d: u64, n: &[u8], k: &[u8]) {
     unsafe {
         ffi::crypto_stream_xsalsa20_tweet_xor(c.as_mut_ptr(), m.as_ptr(), d, n.as_ptr(), k.as_ptr());
-    }
-}
-
-pub fn crypto_onetimeauth(out: &mut[u8], m: &[u8], n: u64, k: &[u8]) {
-    unsafe {
-        ffi::crypto_onetimeauth_poly1305_tweet(out.as_mut_ptr(), m.as_ptr(), n, k.as_ptr());
-    }
-}
-
-pub fn crypto_onetimeauth_verify(h: &[u8], m: &[u8], n: u64, k: &[u8]) {
-    unsafe {
-        ffi::crypto_onetimeauth_poly1305_tweet_verify(h.as_ptr(), m.as_ptr(), n, k.as_ptr());
     }
 }
 


### PR DESCRIPTION
Follows the NaCL c++ API style, caveats from #2  apply.
