### PR TITLE
Simplify error handling and cleanup API

### DIFF
--- a/src/crypto_box.rs
+++ b/src/crypto_box.rs
@@ -1,45 +1,42 @@
 use ffi;
 
+pub const PUBLICKEYBYTES:   usize = 32;
+pub const SECRETKEYBYTES:   usize = 32;
+pub const NONCEBYTES:       usize = 24;
+pub const ZEROBYTES:        usize = 32;
+pub const BOXZEROBYTES:     usize = 16;
+
 #[derive(Debug, Eq, PartialEq)]
-pub enum CryptoBoxErr {
-    CryptoBox,
-    CryptoBoxOpen,
-    KeyGen,
+pub enum Error {
+    Verify,
 }
 
 /// Generate a Curve25519 keypair.
 ///
 /// The `crypto_box_keypair()` function randomly generates a secret key and a
 /// corresponding public key. It puts the secret key into `sk` and returns the
-/// public key. It guarantees that `sk` has `crypto_box_SECRETKEYBYTES` bytes
-/// and that `pk` has crypto_box_PUBLICKEYBYTES bytes.
-///
-/// # Failures
-///
-/// A CryptoBoxErr::Keypair error is returned if an internal error occurs
-/// during key generation.
+/// public key. It guarantees that `sk` has `crypto_box::SECRETKEYBYTES` bytes
+/// and that `pk` has `crypto_box::PUBLICKEYBYTES` bytes.
 ///
 /// # Examples
 ///
 /// Generating a keypair:
 ///
 /// ```
-/// let mut sk = [0 as u8; ffi::crypto_box_SECRETKEYBYTES];
+/// let mut sk = [0 as u8; crypto_box::SECRETKEYBYTES];
 /// let pk = crypto_box_keypair(&mut sk).ok().expect("Keypair failed!");
 /// ```
-///
-pub fn crypto_box_keypair(sk: &mut [u8; ffi::crypto_box_SECRETKEYBYTES])
-    -> Result<[u8; ffi::crypto_box_PUBLICKEYBYTES], CryptoBoxErr> {
+pub fn crypto_box_keypair(sk: &mut [u8; SECRETKEYBYTES])
+-> [u8; PUBLICKEYBYTES] {
 
-    let mut pk = [0 as u8; ffi::crypto_box_PUBLICKEYBYTES];
+    let mut pk = [0 as u8; PUBLICKEYBYTES];
 
     unsafe {
         match ffi::crypto_box_curve25519xsalsa20poly1305_tweet_keypair(
                         pk.as_mut_ptr(),
                         sk.as_mut_ptr()) {
-
-            0 => Ok(pk),
-            _ => Err(CryptoBoxErr::KeyGen),
+            0 => pk,
+            _ => unreachable!("Internal error."),
         }
     }
 }
@@ -50,11 +47,6 @@ pub fn crypto_box_keypair(sk: &mut [u8; ffi::crypto_box_SECRETKEYBYTES])
 /// the sender's secret key `sk`, the receiver's public key `pk`, and a nonce
 /// `n`. The `crypto_box()` function returns the resulting ciphertext `c`.
 ///
-/// # Failures
-///
-/// A `CryptoBoxErr::CryptoBox` is returned if an internal error occurs during
-/// encryption.
-///
 /// # Examples
 ///
 /// Encrypting a message:
@@ -63,13 +55,13 @@ pub fn crypto_box_keypair(sk: &mut [u8; ffi::crypto_box_SECRETKEYBYTES])
 /// let ciphertext = crypto_box(&plaintext, &nonce, &their_public_key,
 ///                             &my_secret_key).ok().expect("Box Failed!");
 /// ```
-pub fn crypto_box(m: &[u8],
-                  n: &[u8; ffi::crypto_box_NONCEBYTES],
-                  pk: &[u8; ffi::crypto_box_PUBLICKEYBYTES],
-                  sk: &[u8; ffi::crypto_box_SECRETKEYBYTES])
--> Result<Vec<u8>, CryptoBoxErr> {
+pub fn crypto_box(m:  &[u8],
+                  n:  &[u8; NONCEBYTES],
+                  pk: &[u8; PUBLICKEYBYTES],
+                  sk: &[u8; SECRETKEYBYTES])
+-> Vec<u8> {
 
-    let mut padded_m = vec![0 as u8; ffi::crypto_box_ZEROBYTES];
+    let mut padded_m = vec![0 as u8; ZEROBYTES];
     padded_m.extend(m.iter().cloned());
     let mut c = vec![0 as u8; padded_m.len()];
 
@@ -81,8 +73,8 @@ pub fn crypto_box(m: &[u8],
                         n.as_ptr(),
                         pk.as_ptr(),
                         sk.as_ptr()) {
-            0 => Ok(c[ffi::crypto_secretbox_BOXZEROBYTES..c.len()].to_vec()),
-            _ => Err(CryptoBoxErr::CryptoBox),
+            0 => c[BOXZEROBYTES..].to_vec(),
+            _ => unreachable!("Internal error."),
         }
     }
 }
@@ -96,27 +88,27 @@ pub fn crypto_box(m: &[u8],
 ///
 /// # Failures
 ///
-/// If an internal error occurs or the ciphertext fails verification, a
-/// `CryptoBoxErr::CryptoBoxOpen` error is returned.
+/// If the ciphertext fails verification, an `Err(Error::Verify)`
+/// is returned.
 ///
 /// # Examples
 ///
-/// Verifying and decrypting a message:
+/// Verify and decrypt a message:
 ///
 /// ```
 /// let plaintext = crypto_box_open(&ciphertext, &nonce, &their_public_key,
 ///                                 &my_secret_key)
 ///                                     .ok()
-///                                     .expect("Box Open Failed!");
+///                                     .expect("Verification Failed!");
 /// ```
 ///
-pub fn crypto_box_open(c: &[u8],
-                       n: &[u8; ffi::crypto_box_NONCEBYTES],
-                       pk: &[u8; ffi::crypto_box_PUBLICKEYBYTES],
-                       sk: &[u8; ffi::crypto_box_SECRETKEYBYTES])
--> Result<Vec<u8>, CryptoBoxErr> {
+pub fn crypto_box_open(c:  &[u8],
+                       n:  &[u8; NONCEBYTES],
+                       pk: &[u8; PUBLICKEYBYTES],
+                       sk: &[u8; SECRETKEYBYTES])
+-> Result<Vec<u8>, Error> {
 
-    let mut padded_c = vec![0 as u8; ffi::crypto_box_BOXZEROBYTES];
+    let mut padded_c = vec![0 as u8; BOXZEROBYTES];
     padded_c.extend(c.iter().cloned());
     let mut m = vec![0 as u8; padded_c.len()];
 
@@ -128,34 +120,33 @@ pub fn crypto_box_open(c: &[u8],
                         n.as_ptr(),
                         pk.as_ptr(),
                         sk.as_ptr()) {
-            0 => Ok(m[ffi::crypto_box_ZEROBYTES..m.len()].to_vec()),
-            _ => Err(CryptoBoxErr::CryptoBoxOpen),
+            0  => Ok(m[ZEROBYTES..m.len()].to_vec()),
+            -1 => Err(Error::Verify),
+            _  => unreachable!("Internal error."),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use ffi;
     use super::*;
 
-    static ALICE_SK: [u8; ffi::crypto_box_SECRETKEYBYTES] =
+    static ALICE_SK: [u8; SECRETKEYBYTES] =
         [244, 198, 125, 80, 217, 96, 158, 20, 19, 178, 135, 17, 29, 153, 157,
          132, 149, 35, 119, 79, 213, 153, 42, 63, 30, 103, 132, 4, 166, 247,
          16, 19];
-    static ALICE_PK: [u8; ffi::crypto_box_PUBLICKEYBYTES] =
+    static ALICE_PK: [u8; PUBLICKEYBYTES] =
         [63, 195, 253, 143, 164, 43, 87, 145, 223, 184, 237, 180, 245, 246,
          118, 139, 188, 95, 209, 250, 47, 2, 247, 214, 77, 149, 202, 126, 200,
          238, 63, 30];
-    static BOB_SK: [u8; ffi::crypto_box_SECRETKEYBYTES] =
+    static BOB_SK: [u8; SECRETKEYBYTES] =
         [191, 47, 36, 109, 103, 198, 78, 27, 47, 111, 50, 117, 34, 249, 175,
          23, 47, 113, 2, 67, 199, 95, 33, 79, 148, 168, 12, 97, 22, 65, 198,
          80];
-    static BOB_PK: [u8; ffi::crypto_box_PUBLICKEYBYTES] =
+    static BOB_PK: [u8; PUBLICKEYBYTES] =
         [249, 6, 3, 156, 96, 233, 80, 243, 198, 63, 57, 145, 19, 15, 71, 205,
          68, 203, 150, 6, 90, 255, 66, 74, 103, 162, 90, 76, 76, 175, 135, 51];
-    static NONCE: [u8; ffi::crypto_box_NONCEBYTES] =
-        [0; ffi::crypto_box_NONCEBYTES];
+    static NONCE: [u8; NONCEBYTES] = [0; NONCEBYTES];
     static M: [u8; 3] = [1, 2, 3];
     static CIPHERTEXT: [u8; 19] = [136, 190, 177, 116, 32, 235, 144, 191, 211,
                                    18, 72, 175, 159, 123, 205, 22, 197, 109,
@@ -164,15 +155,13 @@ mod tests {
     #[test]
     #[allow(unused_variables)]
     fn crypto_box_keypair_ok() {
-        let mut sk = [0 as u8; ffi::crypto_box_SECRETKEYBYTES];
-        let pk = crypto_box_keypair(&mut sk).ok().expect("Keygen failed!");
+        let mut sk = [0 as u8; SECRETKEYBYTES];
+        let pk = crypto_box_keypair(&mut sk);
     }
 
     #[test]
     fn crypto_box_ok() {
-        let c = crypto_box(&M, &NONCE, &BOB_PK, &ALICE_SK)
-                    .ok()
-                    .expect("Box Failed!");
+        let c = crypto_box(&M, &NONCE, &BOB_PK, &ALICE_SK);
         assert_eq!(c, &CIPHERTEXT);
     }
 
@@ -199,15 +188,15 @@ mod tests {
         bad_sk[1] = bad_sk[1] ^ 1;
 
         let result = crypto_box_open(&bad_c, &NONCE, &ALICE_PK, &BOB_SK);
-        assert_eq!(result, Err(CryptoBoxErr::CryptoBoxOpen));
+        assert_eq!(result, Err(Error::Verify));
 
         let result = crypto_box_open(&CIPHERTEXT, &bad_n, &ALICE_PK, &BOB_SK);
-        assert_eq!(result, Err(CryptoBoxErr::CryptoBoxOpen));
+        assert_eq!(result, Err(Error::Verify));
 
         let result = crypto_box_open(&CIPHERTEXT, &NONCE, &bad_pk, &BOB_SK);
-        assert_eq!(result, Err(CryptoBoxErr::CryptoBoxOpen));
+        assert_eq!(result, Err(Error::Verify));
 
         let result = crypto_box_open(&CIPHERTEXT, &NONCE, &ALICE_PK, &bad_sk);
-        assert_eq!(result, Err(CryptoBoxErr::CryptoBoxOpen));
+        assert_eq!(result, Err(Error::Verify));
     }
 }

--- a/src/crypto_hash.rs
+++ b/src/crypto_hash.rs
@@ -1,38 +1,31 @@
 use ffi;
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum CryptoHashErr {
-    Hash,
-}
+pub const BYTES: usize = 64;
 
 /// Hash a message.
 ///
 /// The `crypto_hash()` function hashes a message `m` using `SHA512`. It
 /// returns a hash `h`. The output length `h.size()` is always
-/// `crypto_hash_BYTES()`.
-///
-/// # Failures
-///
-/// If an internal hashing error occurs, `CryptoHashErr::Hash` is returned.
+/// `crypto_hash::BYTES`.
 ///
 /// # Examples
+///
+/// Hash a simple message:
 ///
 /// ```
 /// let m = [1 as u8, 2, 3];
 /// let hashed = crypto_hash(&m);
 /// ```
-///
-pub fn crypto_hash(m: &[u8])
--> Result<[u8; ffi::crypto_hash_BYTES], CryptoHashErr> {
+pub fn crypto_hash(m: &[u8]) -> [u8; BYTES] {
 
-    let mut out = [0 as u8; ffi::crypto_hash_BYTES];
+    let mut out = [0 as u8; BYTES];
 
     unsafe {
         match ffi::crypto_hash_sha512_tweet(out.as_mut_ptr(),
                                             m.as_ptr(),
                                             m.len() as u64) {
-            0 => Ok(out),
-            _ => Err(CryptoHashErr::Hash),
+            0 => out,
+            _ => unreachable!("Internal error."),
         }
     }
 }
@@ -52,10 +45,7 @@ mod tests {
                                    250, 106, 121, 115,  17, 101,  88,  70,
                                    119,   6,  96,  69, 201,  89, 237,  15,
                                    153,  41, 104, 141,   4, 222, 252,  41];
-        let hashed = match crypto_hash(&m) {
-            Ok(v) => v,
-            Err(e) => panic!(e),
-        };
+        let hashed = crypto_hash(&m);
         assert!(hashed.iter().zip(expected.iter()).all(|(a,b)| a == b));
     }
 }

--- a/src/crypto_onetimeauth.rs
+++ b/src/crypto_onetimeauth.rs
@@ -1,63 +1,55 @@
 use ffi;
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum CryptoOnetimeAuthErr {
-    OnetimeAuth,
-    Verify,
-}
+pub const BYTES:    usize = 16;
+pub const KEYBYTES: usize = 32;
 
 /// Authenticate a message.
 ///
 /// The `crypto_onetimeauth()` function authenticates a message `m` using a
 /// secret key `k`, and returns an authenticator `a`. The authenticator length
-/// is always `crypto_onetimeauth_BYTES`.
-///
-/// # Failures
-///
-/// `CryptoOnetimeAuthErr` is returned if an internal error occurs.
+/// is always `crypto_onetimeauth::BYTES`.
 ///
 /// # Examples
 ///
-/// Authenticating a message:
+/// Authenticate a message:
 ///
 /// ```
-/// let authenticator = crypto_onetimeauth(&m, &k)
-///                         .ok()
-///                         .expect("onetimeauth failed!");
+/// let auth = crypto_onetimeauth(&m, &k);
 /// ```
-///
-pub fn crypto_onetimeauth(m: &[u8], k: &[u8; ffi::crypto_onetimeauth_KEYBYTES])
--> Result<[u8; ffi::crypto_onetimeauth_BYTES], CryptoOnetimeAuthErr> {
+pub fn crypto_onetimeauth(m: &[u8], k: &[u8; KEYBYTES]) -> [u8; BYTES] {
 
-    let mut out = [0 as u8; ffi::crypto_onetimeauth_BYTES];
+    let mut auth = [0 as u8; BYTES];
 
     unsafe {
         match ffi::crypto_onetimeauth_poly1305_tweet(
-                        out.as_mut_ptr(),
+                        auth.as_mut_ptr(),
                         m.as_ptr(),
                         m.len() as u64,
                         k.as_ptr()) {
-            0 => Ok(out),
-            _ => Err(CryptoOnetimeAuthErr::OnetimeAuth),
+            0 => auth,
+            _ => unreachable!("Internal error."),
         }
     }
 }
 
 /// Verify a message.
 ///
-/// This function checks that `a` is a correct authenticator of a message `m`
-/// under the secret key `k`.
+/// This function returns `true` if `a` is a correct authenticator of a
+/// message `m` under the secret key `k`
 ///
 /// # Failures
 ///
-/// `CryptoOnetimeAuthErr::Verify` is returned if `m` fails verification.
+/// `false` is returned if `m` fails verification.
 ///
 /// # Examples
 ///
-pub fn crypto_onetimeauth_verify(a: &[u8; ffi::crypto_onetimeauth_BYTES],
+/// ```
+/// let verified = crypto_onetimeauth_verify(&a, &m, &k);
+/// ```
+pub fn crypto_onetimeauth_verify(a: &[u8; BYTES],
                                  m: &[u8],
-                                 k: &[u8; ffi::crypto_onetimeauth_KEYBYTES])
--> Result<(), CryptoOnetimeAuthErr> {
+                                 k: &[u8; KEYBYTES])
+-> bool {
 
     unsafe {
         match ffi::crypto_onetimeauth_poly1305_tweet_verify(
@@ -65,38 +57,35 @@ pub fn crypto_onetimeauth_verify(a: &[u8; ffi::crypto_onetimeauth_BYTES],
                         m.as_ptr(),
                         m.len() as u64,
                         k.as_ptr()) {
-            0 => Ok(()),
-            _ => Err(CryptoOnetimeAuthErr::Verify),
+            0  => true,
+            -1 => false,
+            _  => unreachable!("Internal error."),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use ffi;
     use super::*;
 
     static M: [u8; 3] = [1, 2, 3];
-    static K: [u8; ffi::crypto_onetimeauth_KEYBYTES] =
+    static K: [u8; KEYBYTES] =
         [94, 160, 2, 50, 215, 69, 14, 177, 153, 175, 171, 118, 23, 86, 2, 147,
          51, 121, 188, 153, 175, 42, 81, 94, 184, 117, 143, 111, 237, 69, 51,
          215];
-    static A: [u8; ffi::crypto_onetimeauth_BYTES] =
+    static A: [u8; BYTES] =
         [201, 163, 29, 224, 47, 33, 105, 33, 195, 102, 99, 116, 193, 131, 36,
          245];
 
     #[test]
     pub fn crypto_onetimeauth_ok() {
-        let result = crypto_onetimeauth(&M, &K).ok().expect("failed!");
+        let result = crypto_onetimeauth(&M, &K);
         assert_eq!(result, A);
     }
 
     #[test]
     pub fn crypto_onetimeauth_verify_ok() {
-        let result = crypto_onetimeauth_verify(&A, &M, &K)
-                            .ok()
-                            .expect("failed!");
-        assert_eq!(result, ());
+        assert!(crypto_onetimeauth_verify(&A, &M, &K));
     }
 
     #[test]
@@ -110,13 +99,8 @@ mod tests {
         let mut bad_k = K.clone();
         bad_k[0] = bad_k[0] ^ 1;
 
-        let result = crypto_onetimeauth_verify(&bad_a, &M, &K);
-        assert_eq!(result, Err(CryptoOnetimeAuthErr::Verify));
-
-        let result = crypto_onetimeauth_verify(&A, &bad_m, &K);
-        assert_eq!(result, Err(CryptoOnetimeAuthErr::Verify));
-
-        let result = crypto_onetimeauth_verify(&A, &M, &bad_k);
-        assert_eq!(result, Err(CryptoOnetimeAuthErr::Verify));
+        assert!(!crypto_onetimeauth_verify(&bad_a, &M, &K));
+        assert!(!crypto_onetimeauth_verify(&A, &bad_m, &K));
+        assert!(!crypto_onetimeauth_verify(&A, &M, &bad_k));
     }
 }

--- a/src/crypto_scalarmult.rs
+++ b/src/crypto_scalarmult.rs
@@ -70,21 +70,22 @@ pub fn crypto_scalarmult_base(n: &[u8; ffi::crypto_scalarmult_SCALARBYTES])
 #[cfg(test)]
 mod tests {
     use ffi;
+    use crypto_box;
     use super::*;
 
-    static ALICE_SK: [u8; ffi::crypto_box_SECRETKEYBYTES] =
+    static ALICE_SK: [u8; crypto_box::SECRETKEYBYTES] =
         [57, 205, 241, 233, 180, 183, 151, 187, 107, 78, 102, 249, 229, 237,
          84, 15, 141, 184, 171, 156, 67, 151, 50, 70, 39, 6, 151, 96, 133, 35,
          153, 107];
-    static ALICE_PK: [u8; ffi::crypto_box_PUBLICKEYBYTES] =
+    static ALICE_PK: [u8; crypto_box::PUBLICKEYBYTES] =
         [69, 160, 229, 23, 37, 18, 235, 18, 172, 96, 127, 27, 116, 184, 29,
          126, 110, 167, 201, 252, 47, 24, 75, 52, 37, 36, 22, 233, 195, 126,
          120, 112];
-    static BOB_SK: [u8; ffi::crypto_box_SECRETKEYBYTES] =
+    static BOB_SK: [u8; crypto_box::SECRETKEYBYTES] =
         [176, 134, 132, 212, 9, 176, 83, 50, 95, 0, 85, 176, 31, 248, 219,
          254, 242, 213, 159, 137, 52, 90, 244, 151, 223, 87, 255, 68, 127,
          106, 213, 79];
-    static BOB_PK: [u8; ffi::crypto_box_PUBLICKEYBYTES] =
+    static BOB_PK: [u8; crypto_box::PUBLICKEYBYTES] =
         [160, 181, 63, 165, 91, 192, 71, 127, 69, 218, 113, 100, 33, 110, 128,
          153, 39, 10, 84, 122, 221, 156, 231, 102, 143, 63, 64, 70, 223, 136,
          134, 94];

--- a/src/crypto_scalarmult.rs
+++ b/src/crypto_scalarmult.rs
@@ -1,42 +1,32 @@
 use ffi;
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum CryptoScalarmultErr {
-    Scalarmult,
-    ScalarmultBase,
-}
+pub const BYTES:        usize = 32;
+pub const SCALARBYTES:  usize = 32;
 
 /// Multiply a group element by an integer.
 ///
 /// This function multiplies a group element `p` by an integer `n`. It returns
-/// the resulting group element `q` of length `crypto_scalarmult_BYTES`.
-///
-/// # Failures
-///
-/// If an internal error occurs, `CryptoScalarmultErr::Scalarmult` is returned.
+/// the resulting group element `q` of length `crypto_scalarmult::BYTES`.
 ///
 /// # Examples
 ///
 /// Multiply Bob's public key by Alice's secret key to obtain a shared secret:
 ///
 /// ```
-/// let shared_secret = crypto_scalarmult(alice_sk, bob_pk)
-///                         .ok()
-///                         .expect("scalarmult failed!");
+/// let shared_secret = crypto_scalarmult(alice_sk, bob_pk);
 /// ```
-pub fn crypto_scalarmult(n: &[u8; ffi::crypto_scalarmult_SCALARBYTES],
-                         p: &[u8; ffi::crypto_scalarmult_BYTES])
--> Result<[u8; ffi::crypto_scalarmult_BYTES], CryptoScalarmultErr> {
+pub fn crypto_scalarmult(n: &[u8; SCALARBYTES], p: &[u8; BYTES])
+-> [u8; BYTES] {
 
-    let mut q = [0 as u8; ffi::crypto_scalarmult_BYTES];
+    let mut q = [0 as u8; BYTES];
 
     unsafe {
         match ffi::crypto_scalarmult_curve25519_tweet(
                         q.as_mut_ptr(),
                         n.as_ptr(),
                         p.as_ptr()) {
-            0 => Ok(q),
-            _ => Err(CryptoScalarmultErr::Scalarmult),
+            0 => q,
+            _ => unreachable!("Internal error."),
         }
     }
 }
@@ -45,31 +35,23 @@ pub fn crypto_scalarmult(n: &[u8; ffi::crypto_scalarmult_SCALARBYTES],
 ///
 /// The `crypto_scalarmult_base()` function computes the scalar product of a
 /// standard group element and an integer `n`. It returns the resulting group
-/// element `q` of length `crypto_scalarmult_BYTES`.
-///
-/// # Failures
-///
-/// A `CryptoScalarmultErr::ScalarmultBase` is returned if an internal error
-/// occurs.
-///
-pub fn crypto_scalarmult_base(n: &[u8; ffi::crypto_scalarmult_SCALARBYTES])
--> Result<[u8; ffi::crypto_scalarmult_BYTES], CryptoScalarmultErr> {
+/// element `q` of length `crypto_scalarmult::BYTES`.
+pub fn crypto_scalarmult_base(n: &[u8; SCALARBYTES]) -> [u8; BYTES] {
 
-    let mut q = [0 as u8; ffi::crypto_scalarmult_BYTES];
+    let mut q = [0 as u8; BYTES];
 
     unsafe {
         match ffi::crypto_scalarmult_curve25519_tweet_base(
                         q.as_mut_ptr(),
                         n.as_ptr()) {
-            0 => Ok(q),
-            _ => Err(CryptoScalarmultErr::ScalarmultBase),
+            0 => q,
+            _ => unreachable!("Internal error."),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use ffi;
     use crypto_box;
     use super::*;
 
@@ -89,32 +71,26 @@ mod tests {
         [160, 181, 63, 165, 91, 192, 71, 127, 69, 218, 113, 100, 33, 110, 128,
          153, 39, 10, 84, 122, 221, 156, 231, 102, 143, 63, 64, 70, 223, 136,
          134, 94];
-    static SMULT_OUT: [u8; ffi::crypto_scalarmult_BYTES] =
+    static SMULT_OUT: [u8; BYTES] =
         [38, 16, 230, 128, 26, 181, 100, 196, 135, 142, 113, 109, 103, 105,
          109, 153, 186, 139, 150, 176, 182, 70, 180, 247, 24, 229, 150, 84,
          224, 25, 0, 20];
-    static BASE_OUT: [u8; ffi::crypto_scalarmult_BYTES] =
+    static BASE_OUT: [u8; BYTES] =
         [69, 160, 229, 23, 37, 18, 235, 18, 172, 96, 127, 27, 116, 184, 29,
          126, 110, 167, 201, 252, 47, 24, 75, 52, 37, 36, 22, 233, 195, 126,
          120, 112];
 
     #[test]
     fn crypto_scalarmult_ok() {
-        let r1 = crypto_scalarmult(&ALICE_SK, &BOB_PK)
-                    .ok()
-                    .expect("failed!");
-        let r2 = crypto_scalarmult(&BOB_SK, &ALICE_PK)
-                    .ok()
-                    .expect("failed!");
-        assert_eq!(r1, r2);
-        assert_eq!(r1, SMULT_OUT);
+        let q1 = crypto_scalarmult(&ALICE_SK, &BOB_PK);
+        let q2 = crypto_scalarmult(&BOB_SK, &ALICE_PK);
+        assert_eq!(q1, q2);
+        assert_eq!(q1, SMULT_OUT);
     }
 
     #[test]
     fn crypto_scalarmult_base_ok() {
-        let r1 = crypto_scalarmult_base(&ALICE_SK)
-                    .ok()
-                    .expect("failed!");
-        assert_eq!(r1, BASE_OUT);
+        let q1 = crypto_scalarmult_base(&ALICE_SK);
+        assert_eq!(q1, BASE_OUT);
     }
 }

--- a/src/crypto_secretbox.rs
+++ b/src/crypto_secretbox.rs
@@ -83,7 +83,7 @@ pub fn crypto_secretbox_open(c: &[u8],
                         padded_c.len() as u64,
                         n.as_ptr(),
                         k.as_ptr()) {
-            0 => Ok(m[ffi::crypto_box_ZEROBYTES..m.len()].to_vec()),
+            0 => Ok(m[ffi::crypto_secretbox_ZEROBYTES..m.len()].to_vec()),
             _ => Err(CryptoSecretBoxErr::SecretBoxOpen),
         }
     }

--- a/src/crypto_secretbox.rs
+++ b/src/crypto_secretbox.rs
@@ -1,10 +1,14 @@
 use crypto_onetimeauth;
 use ffi;
 
+pub const KEYBYTES:     usize = 32;
+pub const NONCEBYTES:   usize = 24;
+pub const ZEROBYTES:    usize = 32;
+pub const BOXZEROBYTES: usize = 16;
+
 #[derive(Debug, Eq, PartialEq)]
-pub enum CryptoSecretBoxErr {
-    SecretBox,
-    SecretBoxOpen,
+pub enum Error {
+    Verify,
 }
 
 /// Encrypt and authenticate a message.
@@ -13,9 +17,6 @@ pub enum CryptoSecretBoxErr {
 /// using a secret key `k` and a nonce `n`. The `crypto_secretbox()` function
 /// returns the resulting ciphertext `c`.
 ///
-/// # Failures
-/// A `CryptoSecretBoxErr::SecretBox` is returned if an internal error occurs.
-///
 /// # Examples
 ///
 /// Encrypt and authenticate a message `m`:
@@ -23,14 +24,12 @@ pub enum CryptoSecretBoxErr {
 /// ```
 /// let ciphertext = crypto_secretbox(&plaintext, &nonce, &key);
 /// ```
-///
-pub fn crypto_secretbox(m: &[u8], n: &[u8; ffi::crypto_secretbox_NONCEBYTES],
-                        k: &[u8; ffi::crypto_secretbox_KEYBYTES])
--> Result<Vec<u8>, CryptoSecretBoxErr> {
+pub fn crypto_secretbox(m: &[u8], n: &[u8; NONCEBYTES], k: &[u8; KEYBYTES])
+-> Vec<u8> {
 
-    let mut padded_m = vec![0 as u8; ffi::crypto_secretbox_ZEROBYTES];
+    let mut padded_m = vec![0 as u8; ZEROBYTES];
     padded_m.extend(m.iter().cloned());
-    let mut c = vec![0 as u8; ffi::crypto_secretbox_BOXZEROBYTES +
+    let mut c = vec![0 as u8; BOXZEROBYTES +
                               crypto_onetimeauth::BYTES +
                               m.len()];
 
@@ -41,8 +40,8 @@ pub fn crypto_secretbox(m: &[u8], n: &[u8; ffi::crypto_secretbox_NONCEBYTES],
                         padded_m.len() as u64,
                         n.as_ptr(),
                         k.as_ptr()) {
-            0 => Ok(c[ffi::crypto_secretbox_BOXZEROBYTES..c.len()].to_vec()),
-            _ => Err(CryptoSecretBoxErr::SecretBox),
+            0 => c[BOXZEROBYTES..].to_vec(),
+            _ => unreachable!("Internal error."),
         }
     }
 }
@@ -55,8 +54,7 @@ pub fn crypto_secretbox(m: &[u8], n: &[u8; ffi::crypto_secretbox_NONCEBYTES],
 ///
 /// # Failures
 ///
-/// A `CryptoSecretBoxErr::SecretBoxOpen` is returned if the ciphertext fails
-/// verification.
+/// An `Error::Verify` is returned if the ciphertext fails verification.
 ///
 /// # Examples
 ///
@@ -67,13 +65,12 @@ pub fn crypto_secretbox(m: &[u8], n: &[u8; ffi::crypto_secretbox_NONCEBYTES],
 ///                        .ok()
 ///                        .expect("Verification failed!");
 /// ```
-///
 pub fn crypto_secretbox_open(c: &[u8],
-                             n: &[u8; ffi::crypto_secretbox_NONCEBYTES],
-                             k: &[u8; ffi::crypto_secretbox_KEYBYTES])
--> Result<Vec<u8>, CryptoSecretBoxErr> {
+                             n: &[u8; NONCEBYTES],
+                             k: &[u8; KEYBYTES])
+-> Result<Vec<u8>, Error> {
 
-    let mut padded_c = vec![0 as u8; ffi::crypto_secretbox_BOXZEROBYTES];
+    let mut padded_c = vec![0 as u8; BOXZEROBYTES];
     padded_c.extend(c.iter().cloned());
     let mut m = vec![0 as u8; padded_c.len()];
 
@@ -84,8 +81,9 @@ pub fn crypto_secretbox_open(c: &[u8],
                         padded_c.len() as u64,
                         n.as_ptr(),
                         k.as_ptr()) {
-            0 => Ok(m[ffi::crypto_secretbox_ZEROBYTES..m.len()].to_vec()),
-            _ => Err(CryptoSecretBoxErr::SecretBoxOpen),
+            0  => Ok(m[ZEROBYTES..].to_vec()),
+            -1 => Err(Error::Verify),
+            _  => unreachable!("Internal error."),
         }
     }
 }
@@ -93,22 +91,18 @@ pub fn crypto_secretbox_open(c: &[u8],
 #[cfg(test)]
 mod tests {
     use crypto_onetimeauth;
-    use ffi;
     use super::*;
 
     static C: [u8; crypto_onetimeauth::BYTES+3] =
         [126, 79, 196, 241, 56, 117, 222, 2, 146, 56, 182, 245, 242, 134, 22,
          3, 199, 60, 184];
     static M: [u8; 3] = [1, 2, 3];
-    static N: [u8; ffi::crypto_secretbox_NONCEBYTES] =
-        [0; ffi::crypto_secretbox_NONCEBYTES];
-    static K: [u8; ffi::crypto_secretbox_KEYBYTES] =
-        [0; ffi::crypto_secretbox_KEYBYTES];
+    static N: [u8; NONCEBYTES] = [0; NONCEBYTES];
+    static K: [u8; KEYBYTES] = [0; KEYBYTES];
 
     #[test]
     fn crypto_secretbox_ok() {
-        let c = crypto_secretbox(&M, &N, &K).ok().expect("failed!");
-        assert_eq!(c, C);
+        assert_eq!(crypto_secretbox(&M, &N, &K), C);
     }
 
     #[test]
@@ -121,18 +115,18 @@ mod tests {
 
     #[test]
     fn crypto_secretbox_open_fail() {
-        let bad_n = [1 as u8; ffi::crypto_secretbox_NONCEBYTES];
-        let bad_k = [1 as u8; ffi::crypto_secretbox_KEYBYTES];
+        let bad_n = [1 as u8; NONCEBYTES];
+        let bad_k = [1 as u8; KEYBYTES];
         let mut bad_c = C.clone();
         bad_c[0] = bad_c[0] ^ 1;
 
         let result = crypto_secretbox_open(&C, &bad_n, &K);
-        assert!(result == Err(CryptoSecretBoxErr::SecretBoxOpen));
+        assert!(result == Err(Error::Verify));
 
         let result = crypto_secretbox_open(&C, &N, &bad_k);
-        assert!(result == Err(CryptoSecretBoxErr::SecretBoxOpen));
+        assert!(result == Err(Error::Verify));
 
         let result = crypto_secretbox_open(&bad_c, &N, &K);
-        assert!(result == Err(CryptoSecretBoxErr::SecretBoxOpen));
+        assert!(result == Err(Error::Verify));
     }
 }

--- a/src/crypto_secretbox.rs
+++ b/src/crypto_secretbox.rs
@@ -1,3 +1,4 @@
+use crypto_onetimeauth;
 use ffi;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -30,7 +31,7 @@ pub fn crypto_secretbox(m: &[u8], n: &[u8; ffi::crypto_secretbox_NONCEBYTES],
     let mut padded_m = vec![0 as u8; ffi::crypto_secretbox_ZEROBYTES];
     padded_m.extend(m.iter().cloned());
     let mut c = vec![0 as u8; ffi::crypto_secretbox_BOXZEROBYTES +
-                              ffi::crypto_onetimeauth_BYTES +
+                              crypto_onetimeauth::BYTES +
                               m.len()];
 
     unsafe {
@@ -91,10 +92,11 @@ pub fn crypto_secretbox_open(c: &[u8],
 
 #[cfg(test)]
 mod tests {
+    use crypto_onetimeauth;
     use ffi;
     use super::*;
 
-    static C: [u8; ffi::crypto_onetimeauth_BYTES+3] =
+    static C: [u8; crypto_onetimeauth::BYTES+3] =
         [126, 79, 196, 241, 56, 117, 222, 2, 146, 56, 182, 245, 242, 134, 22,
          3, 199, 60, 184];
     static M: [u8; 3] = [1, 2, 3];

--- a/src/crypto_verify.rs
+++ b/src/crypto_verify.rs
@@ -1,14 +1,9 @@
 use ffi;
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum CryptoVerifyErr {
-    Verify,
-}
-
 /// Constant time equality test for two 16-byte arrays.
 ///
-/// The `crypto_verify_16()` function returns Ok(()) if `x[0], x[1], ..., x[15]`
-/// are the same as `y[0], y[1], ..., y[15]`.
+/// The `crypto_verify_16()` function returns `true` iff `x[0], x[1], ..., x[15]`
+/// are the same as `y[0], y[1], ..., y[15]`, `false` otherwise.
 ///
 /// This function is safe to use for secrets `x[0], x[1], ..., x[15], y[0],
 /// y[1], ..., y[15]`. The time taken by `crypto_verify_16()` is independent of/// the contents of `x[0], x[1], ..., x[15], y[0], y[1], ..., y[15]`. In
@@ -16,31 +11,25 @@ pub enum CryptoVerifyErr {
 /// that depends on the longest matching prefix of `x` and `y`, often allowing
 /// easy timing attacks. 
 ///
-/// # Failures
-///
-/// If `x != y`, a `CryptoVerifyErr::Verify` is returned.
-///
 /// # Examples
 ///
 /// ```
-/// crypto_verify_16(&x, &y).ok().expect("Verification failed!");
+/// let equal = crypto_verify_16(&x, &y);
 /// ```
-///
-pub fn crypto_verify_16(x: &[u8; 16], y: &[u8; 16])
--> Result<(), CryptoVerifyErr> {
+pub fn crypto_verify_16(x: &[u8; 16], y: &[u8; 16]) -> bool {
     unsafe {
         match ffi::crypto_verify_16_tweet(x.as_ptr(), y.as_ptr()) {
-            0 => Ok(()),
-            -1 => Err(CryptoVerifyErr::Verify),
-            _ => unreachable!("Internal error."),
+            0  => true,
+            -1 => false,
+            _  => unreachable!("Internal error."),
         }
     }
 }
 
 /// Constant time equality test for two 32-byte arrays.
 ///
-/// The `crypto_verify_32()` function returns Ok(()) if `x[0], x[1], ..., x[31]`
-/// are the same as `y[0], y[1], ..., y[31]`.
+/// The `crypto_verify_32()` function returns `true` iff `x[0], x[1], ..., x[31]`
+/// are the same as `y[0], y[1], ..., y[31]`, `false` otherwise.
 ///
 /// This function is safe to use for secrets `x[0], x[1], ..., x[31], y[0],
 /// y[1], ..., y[31]`. The time taken by `crypto_verify_16()` is independent of/// the contents of `x[0], x[1], ..., x[31], y[0], y[1], ..., y[31]`. In
@@ -48,23 +37,17 @@ pub fn crypto_verify_16(x: &[u8; 16], y: &[u8; 16])
 /// that depends on the longest matching prefix of `x` and `y`, often allowing
 /// easy timing attacks. 
 ///
-/// # Failures
-///
-/// If `x != y`, a `CryptoVerifyErr::Verify` is returned.
-///
 /// # Examples
 ///
 /// ```
-/// crypto_verify_31(&x, &y).ok().expect("Verification failed!");
+/// let equal = crypto_verify_31(&x, &y);
 /// ```
-///
-pub fn crypto_verify_32(x: &[u8; 32], y: &[u8; 32])
--> Result<(), CryptoVerifyErr> {
+pub fn crypto_verify_32(x: &[u8; 32], y: &[u8; 32]) -> bool {
     unsafe {
         match ffi::crypto_verify_32_tweet(x.as_ptr(), y.as_ptr()) {
-            0 => Ok(()),
-            -1 => Err(CryptoVerifyErr::Verify),
-            _ => unreachable!("Internal error."),
+            0  => true,
+            -1 => false,
+            _  => unreachable!("Internal error."),
         }
     }
 }
@@ -77,8 +60,7 @@ mod tests {
     fn crypto_verify_16_ok() {
         let x = [0 as u8; 16];
         let y = [0 as u8; 16];
-        let result = crypto_verify_16(&x, &y).unwrap();
-        assert_eq!(result, ());
+        assert!(crypto_verify_16(&x, &y));
     }
 
     #[test]
@@ -86,16 +68,14 @@ mod tests {
         let x = [0 as u8; 16];
         let mut y = [0 as u8; 16];
         y[4] = 1;
-        let result = crypto_verify_16(&x, &y);
-        assert_eq!(result, Err(CryptoVerifyErr::Verify));
+        assert!(!crypto_verify_16(&x, &y));
     }
 
     #[test]
     fn crypto_verify_32_ok() {
         let x = [0 as u8; 32];
         let y = [0 as u8; 32];
-        let result = crypto_verify_32(&x, &y).unwrap();
-        assert_eq!(result, ());
+        assert!(crypto_verify_32(&x, &y));
     }
 
     #[test]
@@ -103,7 +83,6 @@ mod tests {
         let x = [0 as u8; 32];
         let mut y = [0 as u8; 32];
         y[24] = 1;
-        let result = crypto_verify_32(&x, &y);
-        assert_eq!(result, Err(CryptoVerifyErr::Verify));
+        assert!(!crypto_verify_32(&x, &y));
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4,7 +4,10 @@ extern {
     pub fn crypto_verify_16_tweet(x: *const u8, y: *const u8) -> c_int;
     pub fn crypto_verify_32_tweet(x: *const u8, y: *const u8) -> c_int;
 
-    pub fn crypto_stream_xsalsa20_tweet(c: *mut u8, d: u64, n: *const u8, k: *const u8) -> c_int;
+    pub fn crypto_stream_xsalsa20_tweet(c: *mut u8, d: u64, n: *const u8,
+                                        k: *const u8)
+    -> c_int;
+
     pub fn crypto_stream_xsalsa20_tweet_xor(c: *mut u8, m: *const u8, d: u64, n: *const u8, k: *const u8) -> c_int;
 
     pub fn crypto_onetimeauth_poly1305_tweet(out: *mut u8, m: *const u8, n: u64, k: *const u8) -> c_int;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,13 +6,6 @@ use libc::{c_int};
 pub const crypto_auth_BYTES: usize = 32;
 pub const crypto_auth_KEYBYTES: usize = 32;
 
-pub const crypto_box_PUBLICKEYBYTES: usize = 32;
-pub const crypto_box_SECRETKEYBYTES: usize = 32;
-pub const crypto_box_NONCEBYTES: usize = 24;
-pub const crypto_box_ZEROBYTES: usize = 32;
-pub const crypto_box_BOXZEROBYTES: usize = 16;
-pub const crypto_box_BEFORENMBYTES: usize = 32;
-
 pub const crypto_hash_BYTES: usize = 64;
 
 pub const crypto_onetimeauth_BYTES: usize = 16;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,17 +3,6 @@
 
 use libc::{c_int};
 
-pub const crypto_auth_BYTES: usize = 32;
-pub const crypto_auth_KEYBYTES: usize = 32;
-
-pub const crypto_hash_BYTES: usize = 64;
-
-pub const crypto_onetimeauth_BYTES: usize = 16;
-pub const crypto_onetimeauth_KEYBYTES: usize = 32;
-
-pub const crypto_scalarmult_BYTES: usize = 32;
-pub const crypto_scalarmult_SCALARBYTES: usize = 32;
-
 pub const crypto_secretbox_KEYBYTES: usize = 32;
 pub const crypto_secretbox_NONCEBYTES: usize = 24;
 pub const crypto_secretbox_ZEROBYTES: usize = 32;
@@ -25,7 +14,6 @@ pub const crypto_sign_BYTES: usize = 64;
 
 pub const crypto_stream_KEYBYTES: usize = 32;
 pub const crypto_stream_NONCEBYTES: usize = 24;
-
 
 extern {
     pub fn crypto_verify_16_tweet(x: *const u8, y: *const u8) -> c_int;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,10 +3,6 @@
 
 use libc::{c_int};
 
-pub const crypto_sign_PUBLICKEYBYTES: usize = 32;
-pub const crypto_sign_SECRETKEYBYTES: usize = 64;
-pub const crypto_sign_BYTES: usize = 64;
-
 pub const crypto_stream_KEYBYTES: usize = 32;
 pub const crypto_stream_NONCEBYTES: usize = 24;
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,56 +1,110 @@
 use libc::{c_int};
 
 extern {
-    pub fn crypto_verify_16_tweet(x: *const u8, y: *const u8) -> c_int;
-    pub fn crypto_verify_32_tweet(x: *const u8, y: *const u8) -> c_int;
+    // crypto_box functions
+    pub fn crypto_box_curve25519xsalsa20poly1305_tweet_keypair(pk: *mut u8,
+                                                               sk: *mut u8)
+    -> c_int;
 
-    pub fn crypto_stream_xsalsa20_tweet(c: *mut u8, d: u64, n: *const u8,
+    pub fn crypto_box_curve25519xsalsa20poly1305_tweet(c: *mut u8,
+                                                       m: *const u8,
+                                                       d: u64,
+                                                       n: *const u8,
+                                                       y: *const u8,
+                                                       x: *const u8)
+    -> c_int;
+
+    pub fn crypto_box_curve25519xsalsa20poly1305_tweet_open(m: *mut u8,
+                                                            c: *const u8,
+                                                            d: u64,
+                                                            n: *const u8,
+                                                            y: *const u8,
+                                                            x: *const u8)
+    -> c_int;
+    
+    // crypto_scalarmult functions
+    pub fn crypto_scalarmult_curve25519_tweet(q: *mut u8,
+                                              n: *const u8,
+                                              p: *const u8)
+    -> c_int;
+
+    pub fn crypto_scalarmult_curve25519_tweet_base(q: *mut u8,
+                                                   n: *const u8)
+    -> c_int;
+
+    // crypto_sign functions
+    pub fn crypto_sign_ed25519_tweet_keypair(pk: *mut u8,
+                                             sk: *mut u8)
+    -> c_int;
+
+    pub fn crypto_sign_ed25519_tweet(sm: *mut u8,
+                                     smlen: *mut u64,
+                                     m: *const u8,
+                                     n: u64,
+                                     sk: *const u8)
+    -> c_int;
+
+    pub fn crypto_sign_ed25519_tweet_open(m: *mut u8,
+                                          mlen: *mut u64,
+                                          sm: *const u8,
+                                          n: u64,
+                                          pk: *const u8)
+    -> c_int;
+
+    // crypto_secretbox functions
+    pub fn crypto_secretbox_xsalsa20poly1305_tweet(c: *mut u8,
+                                                   m: *const u8,
+                                                   d: u64,
+                                                   n: *const u8,
+                                                   k: *const u8)
+    -> c_int;
+
+    pub fn crypto_secretbox_xsalsa20poly1305_tweet_open(m: *mut u8,
+                                                        c: *const u8,
+                                                        d: u64,
+                                                        n: *const u8,
+                                                        k: *const u8)
+    -> c_int;
+
+    // crypto_stream functions
+    pub fn crypto_stream_xsalsa20_tweet(c: *mut u8,
+                                        d: u64,
+                                        n: *const u8,
                                         k: *const u8)
     -> c_int;
 
-    pub fn crypto_stream_xsalsa20_tweet_xor(c: *mut u8, m: *const u8, d: u64, n: *const u8, k: *const u8) -> c_int;
+    pub fn crypto_stream_xsalsa20_tweet_xor(c: *mut u8,
+                                            m: *const u8,
+                                            d: u64,
+                                            n: *const u8,
+                                            k: *const u8)
+    -> c_int;
 
-    pub fn crypto_onetimeauth_poly1305_tweet(out: *mut u8, m: *const u8, n: u64, k: *const u8) -> c_int;
-    pub fn crypto_onetimeauth_poly1305_tweet_verify(h: *const u8, m: *const u8, n: u64, k: *const u8) -> c_int;
+    // crypto_onetimeauth functions
+    pub fn crypto_onetimeauth_poly1305_tweet(out: *mut u8,
+                                             m: *const u8,
+                                             n: u64,
+                                             k: *const u8)
+    -> c_int;
 
-    pub fn crypto_scalarmult_curve25519_tweet(q: *mut u8, n: *const u8, p: *const u8) -> c_int;
-    pub fn crypto_scalarmult_curve25519_tweet_base(q: *mut u8, n: *const u8) -> c_int;
+    pub fn crypto_onetimeauth_poly1305_tweet_verify(h: *const u8,
+                                                    m: *const u8,
+                                                    n: u64,
+                                                    k: *const u8)
+    -> c_int;
 
-    pub fn crypto_box_curve25519xsalsa20poly1305_tweet_keypair(
-        pk: *mut u8, sk: *mut u8)
-        -> c_int;
+    // crypto_hash functions
+    pub fn crypto_hash_sha512_tweet(out: *mut u8,
+                                    m: *const u8,
+                                    n: u64)
+    -> c_int;
 
-    pub fn crypto_box_curve25519xsalsa20poly1305_tweet(
-        c: *mut u8, m: *const u8, d: u64, n: *const u8, y: *const u8,
-        x: *const u8)
-        -> c_int;
+    // crypto_verify functions
+    pub fn crypto_verify_16_tweet(x: *const u8,
+                                  y: *const u8)
+    -> c_int;
 
-    pub fn crypto_box_curve25519xsalsa20poly1305_tweet_open(
-        m: *mut u8, c: *const u8, d: u64, n: *const u8, y: *const u8,
-        x: *const u8)
-        -> c_int;
-
-    pub fn crypto_secretbox_xsalsa20poly1305_tweet(
-        c: *mut u8, m: *const u8, d: u64, n: *const u8, k: *const u8)
-        -> c_int;
-
-    pub fn crypto_secretbox_xsalsa20poly1305_tweet_open(
-        m: *mut u8, c: *const u8, d: u64, n: *const u8, k: *const u8)
-        -> c_int;
-
-    pub fn crypto_hash_sha512_tweet(
-        out: *mut u8, m: *const u8, n: u64)
-        -> c_int;
-
-    pub fn crypto_sign_ed25519_tweet_keypair(
-        pk: *mut u8, sk: *mut u8)
-        -> c_int;
-
-    pub fn crypto_sign_ed25519_tweet(
-        sm: *mut u8, smlen: *mut u64, m: *const u8, n: u64, sk: *const u8)
-        -> c_int;
-
-    pub fn crypto_sign_ed25519_tweet_open(
-        m: *mut u8, mlen: *mut u64, sm: *const u8, n: u64,
-        pk: *const u8) -> c_int;
+    pub fn crypto_verify_32_tweet(x: *const u8,
+                                  y: *const u8)
+    -> c_int;
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,10 +1,4 @@
-#![allow(non_upper_case_globals)]
-#![allow(dead_code)]  // TODO: Remove this later.
-
 use libc::{c_int};
-
-pub const crypto_stream_KEYBYTES: usize = 32;
-pub const crypto_stream_NONCEBYTES: usize = 24;
 
 extern {
     pub fn crypto_verify_16_tweet(x: *const u8, y: *const u8) -> c_int;
@@ -21,18 +15,6 @@ extern {
 
     pub fn crypto_box_curve25519xsalsa20poly1305_tweet_keypair(
         pk: *mut u8, sk: *mut u8)
-        -> c_int;
-
-    pub fn crypto_box_curve25519xsalsa20poly1305_tweet_beforenm(
-        k: *mut u8, y: *const u8, x: *const u8)
-        -> c_int;
-
-    pub fn crypto_box_curve25519xsalsa20poly1305_tweet_afternm(
-        c: *mut u8, m: *const u8, d: u64, n: *const u8, k: *const u8)
-        -> c_int;
-
-    pub fn crypto_box_curve25519xsalsa20poly1305_tweet_open_afternm(
-        m: *mut u8, c: *const u8, d: u64, n: *const u8, k: *const u8)
         -> c_int;
 
     pub fn crypto_box_curve25519xsalsa20poly1305_tweet(

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,11 +3,6 @@
 
 use libc::{c_int};
 
-pub const crypto_secretbox_KEYBYTES: usize = 32;
-pub const crypto_secretbox_NONCEBYTES: usize = 24;
-pub const crypto_secretbox_ZEROBYTES: usize = 32;
-pub const crypto_secretbox_BOXZEROBYTES: usize = 16;
-
 pub const crypto_sign_PUBLICKEYBYTES: usize = 32;
 pub const crypto_sign_SECRETKEYBYTES: usize = 64;
 pub const crypto_sign_BYTES: usize = 64;


### PR DESCRIPTION
This pull request drastically simplifies error handling across all modules and makes the API semantically nicer to use (also us to remove the directives turning off compiler warnings).
### Simplified Error Handling
#### Return Values

Previously, every function returned a `Result<T, SomeModuleErr::SomeErr>`. However, a number of core tweetnacl functions (the majority) actually cannot fail (barring some catastrophic internal error). These functions, such as `crypto_XXX_keypair()`, now just directly return a `&[u8]` or `Vec<u8>` as appropriate and ditch the `Result` entirely.

Other functions, such as `crypto_verify_XXX()` now return a bool.

The only functions that return a `Result` are those that are expected to either return data or an error, such as the `crypto_XXX_open()` family of functions.

The `unreachable!()` macro is used extensively, and the number of module-level error `enum`s is now greatly reduced.
#### Naming

Previously, error enums were named something like `CryptoSignErr::CryptoSignOpen`. Now, since they have proper namespacing, all error enums are simply `Error` (and would be accessed like `crypto_sign::Error::Verify`).
### Constants

Previously, we had defined crate constants in `ffi.rs`. Constants are now defined in the `.rs` file in which they are used. For instance, `crypto_secretbox_KEYBYTES` is defined in `crypto_secretbox.rs` as `KEYBYTES`, and would be used like `crypto_secretbox::KEYBYTES`.
### FFI Cleanup

Functions in `ffi.rs` were cleaned up a bit to make them easier to read.
### Issues

This pull request closes #13 and #14
