### PR TITLE
Fix #23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ name = "tweetnacl_rs"
 crate-type = ["staticlib"]
 
 [build-dependencies]
-gcc="0.3"
+gcc = "0.3"
 
 [dependencies]
-libc="*"
-rand="*"
+lazy_static = "*"
+libc = "*"
+rand = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate lazy_static;
 extern crate libc;
 extern crate rand;
 

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -1,10 +1,19 @@
 use rand::{OsRng, Rng};
 use std::slice;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref RNG: Mutex<OsRng> =
+        Mutex::new(OsRng::new().ok().expect("OsRng failed!"));
+}
 
 #[no_mangle]
 pub unsafe extern fn randombytes(buf: *mut u8, nbytes: u64) {
     assert!(!buf.is_null());
-    let mut rng = OsRng::new().ok().expect("OSRNG failed.");
-    let mut bytes = slice::from_raw_parts_mut(buf, nbytes as usize);
-    rng.fill_bytes(bytes);
+    //let mut rng = OsRng::new().ok().expect("OSRNG failed.");
+    //let mut bytes = slice::from_raw_parts_mut(buf, nbytes as usize);
+    //rng.fill_bytes(bytes);
+    RNG.lock().unwrap().fill_bytes(
+        slice::from_raw_parts_mut(buf, nbytes as usize)
+    );
 }

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -10,9 +10,6 @@ lazy_static! {
 #[no_mangle]
 pub unsafe extern fn randombytes(buf: *mut u8, nbytes: u64) {
     assert!(!buf.is_null());
-    //let mut rng = OsRng::new().ok().expect("OSRNG failed.");
-    //let mut bytes = slice::from_raw_parts_mut(buf, nbytes as usize);
-    //rng.fill_bytes(bytes);
     RNG.lock().unwrap().fill_bytes(
         slice::from_raw_parts_mut(buf, nbytes as usize)
     );


### PR DESCRIPTION
This PR uses the [lazy_static](https://crates.io/crates/lazy_static) crate to use a persistent `OsRng` instance in `randombytes.rs`. This lets of avoid creating a new `OsRng` on every `randombytes` call (i.e. opening/closing /dev/urandom on Linux or creating/destroying a crypto context on Windows).

In the future, we may want to consider implementing this in a custom way to be more efficient since we don't actually _need_ the atomicity checks going on here, since `tweetnacl` itself is threadsafe.

This PR closes #23 
